### PR TITLE
print help output when no arguments are passed

### DIFF
--- a/baa.sh
+++ b/baa.sh
@@ -125,6 +125,13 @@ print_asciiart() {
 }
 
 
+ #f the script is executed without arguments, print help
+if [ "$#" -eq 0 ]; then
+    ( echo "ERROR Missing arguments!" >&2 ) \
+    && ( print_help >&2 ) \
+    && exit 1;
+fi;
+
 while getopts hprs:vV flag; do
   validate_tools
   case ${flag} in


### PR DESCRIPTION
Fixes issue #1 - may need to be adjusted to match styling and/or proper placement in script.

```
$ ./baa.sh ; echo $?
ERROR Missing arguments!
Usage:  [-hpvV] [-r] [-s SEARCH]
 Options:
   -r         Get Random Ascii Art.
   -h         Print this help.
   -p         Print Ascii Art Categories.
   -s STRING  Search Ascii Art.
   -v         Be verbose.
   -V         Print the Version.

 baa - Bash Ascii Art is a CLI tool to search and fetch the ascii art
 hosted in http://chris.com

 Exit Codes:
    0    Success
    1    Failed
1
```